### PR TITLE
Sync with rust nightly.

### DIFF
--- a/benches/builtin.rs
+++ b/benches/builtin.rs
@@ -1,14 +1,15 @@
 
-#![feature(core, test)]
+#![feature(test)]
 
 extern crate test;
+extern crate num;
 extern crate rand;
 extern crate glm;
 
 use glm::*;
 use glm::ext::*;
 use test::Bencher;
-use std::num::Float;
+use num::Float;
 use rand::{ IsaacRng, Rng };
 
 #[path="common/macros.rs"]

--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -24,8 +24,8 @@ macro_rules! bench_binfn(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems1: Vec<$t1> = range(0, LEN).map(|_| rng.gen::<$t1>()).collect();
-            let elems2: Vec<$t2> = range(0, LEN).map(|_| rng.gen::<$t2>()).collect();
+            let elems1: Vec<$t1> = (0..LEN).map(|_| rng.gen::<$t1>()).collect();
+            let elems2: Vec<$t2> = (0..EN).map(|_| rng.gen::<$t2>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -47,8 +47,8 @@ macro_rules! bench_binfn_deref(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems1: Vec<$t1> = range(0, LEN).map(|_| rng.gen::<$t1>()).collect();
-            let elems2: Vec<$t2> = range(0, LEN).map(|_| rng.gen::<$t2>()).collect();
+            let elems1: Vec<$t1> = (0 .. LEN).map(|_| rng.gen::<$t1>()).collect();
+            let elems2: Vec<$t2> = (0 .. LEN).map(|_| rng.gen::<$t2>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -70,7 +70,7 @@ macro_rules! bench_unifn(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems: Vec<$t> = range(0, LEN).map(|_| rng.gen::<$t>()).collect();
+            let elems: Vec<$t> = (0..EN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -92,7 +92,7 @@ macro_rules! bench_unifn_deref(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems: Vec<$t> = range(0, LEN).map(|_| rng.gen::<$t>()).collect();
+            let elems: Vec<$t> = (0..LEN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -114,8 +114,8 @@ macro_rules! bench_binop(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems1: Vec<$t1> = range(0, LEN).map(|_| rng.gen::<$t1>()).collect();
-            let elems2: Vec<$t2> = range(0, LEN).map(|_| rng.gen::<$t2>()).collect();
+            let elems1: Vec<$t1> = (0..LEN).map(|_| rng.gen::<$t1>()).collect();
+            let elems2: Vec<$t2> = (0..LEN).map(|_| rng.gen::<$t2>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -137,8 +137,8 @@ macro_rules! bench_binop_deref(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let elems1: Vec<$t1> = range(0, LEN).map(|_| rng.gen::<$t1>()).collect();
-            let elems2: Vec<$t2> = range(0, LEN).map(|_| rng.gen::<$t2>()).collect();
+            let elems1: Vec<$t1> = (0..LEN).map(|_| rng.gen::<$t1>()).collect();
+            let elems2: Vec<$t2> = (0..LEN).map(|_| rng.gen::<$t2>()).collect();
             let mut i = 0;
 
             bh.iter(|| {
@@ -160,7 +160,7 @@ macro_rules! bench_uniop(
 
             let mut rng = IsaacRng::new_unseeded();
 
-            let mut elems: Vec<$t> = range(0, LEN).map(|_| rng.gen::<$t>()).collect();
+            let mut elems: Vec<$t> = (0..LEN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
 
             bh.iter(|| {

--- a/src/builtin/common.rs
+++ b/src/builtin/common.rs
@@ -27,10 +27,10 @@ use basenum::*;
 use traits::*;
 use vec::traits::{ GenVec, GenFloatVec, GenNumVec };
 use vec::vec::{ Vector2, Vector3, Vector4 };
+use cast::PrimCast;
 use std::mem;
-use std::num::{ cast, Float};
 use std::ops::Rem;
-use num::{ One, Zero };
+use num::{ Float, One, Zero };
 
 pub trait FloatIntRel<E: BaseFloat, I: BaseInt, GI: GenInt<I>>: GenFloat<E> {
     // float -> int
@@ -82,9 +82,9 @@ macro_rules! impl_vec_FloatIntRel {
                 }
                 #[inline]
                 fn split_int<F: Fn(E) -> (E, I)>(&self, fun: F) -> ($t<E>, $t<I>) {
-                    let mut f = <$t<E> as Zero>::zero();
-                    let mut i = <$t<I> as Zero>::zero();
-                    let dim = <$t<E> as GenVec<E>>::dim();
+                    let mut f = $t::<E>::zero();
+                    let mut i = $t::<I>::zero();
+                    let dim = $t::<E>::dim();
                     for j in 0..dim {
                         let (a, b) = fun(self[j]);
                         f[j] = a;
@@ -192,7 +192,7 @@ impl_vec_NumBoolRel! {
 /// # Example
 ///
 /// ```
-/// use glm::{ abs, dvec4, Signed };
+/// use glm::{ abs, dvec4, SignedNum };
 ///
 /// assert_eq!(abs(-1_f32), 1.);
 /// let v4 = dvec4(0., 100., -2., -3.);
@@ -200,9 +200,9 @@ impl_vec_NumBoolRel! {
 /// assert_eq!(abs(v4), dvec4(0., 100., 2., 3.));
 /// ```
 #[inline(always)]
-pub fn abs<S: Signed + BaseNum, T: GenNum<S>>(x: T) -> T {
+pub fn abs<S: SignedNum + BaseNum, T: GenNum<S>>(x: T) -> T {
     x.map(|s: S| {
-        Signed::abs(&s)
+        SignedNum::abs(&s)
     })
 }
 
@@ -217,9 +217,9 @@ pub fn abs<S: Signed + BaseNum, T: GenNum<S>>(x: T) -> T {
 /// assert_eq!(sign(vec3(-100., 2., 0.)), vec3(-1., 1., 0.));
 /// ```
 #[inline(always)]
-pub fn sign<S: Signed + BaseNum, T: GenNum<S>>(x: T) -> T {
+pub fn sign<S: SignedNum + BaseNum, T: GenNum<S>>(x: T) -> T {
     x.map(|s: S| {
-        Signed::sign(&s)
+        SignedNum::sign(&s)
     })
 }
 
@@ -289,12 +289,12 @@ pub fn round<F: BaseFloat, T: GenFloat<F>>(x: T) -> T {
 #[allow(non_snake_case)]
 pub fn roundEven<F: BaseFloat, T: GenFloat<F>>(x: T) -> T {
     x.map(|f| -> F {
-        let ling = <F as Zero>::zero();
-        let yi = <F as One>::one();
+        let ling = F::zero();
+        let yi = F::one();
         let er = yi + yi;
 
         let int = f.trunc();
-        if f.fract().abs() != cast(0.5).unwrap() {
+        if f.fract().abs() != F::from(0.5).unwrap() {
             f.round()
         } else if int % er == ling {
             int
@@ -520,7 +520,7 @@ pub fn clamp_s<S: BaseNum, T: GenNumVec<S>>(x: T, min_val: S, max_val: S) -> T {
 /// ```
 #[inline(always)]
 pub fn mix<F: BaseFloat, T: GenFloat<F>>(x: T, y: T, a: T) -> T {
-    let yi = <T as One>::one();
+    let yi = T::one();
     x * (yi - a) + y * a
 }
 
@@ -542,7 +542,7 @@ pub fn mix<F: BaseFloat, T: GenFloat<F>>(x: T, y: T, a: T) -> T {
 /// ```
 #[inline(always)]
 pub fn mix_s<F: BaseFloat, T: GenFloatVec<F>>(x: T, y: T, a: F) -> T {
-    let yi = <F as One>::one();
+    let yi = F::one();
     x * (yi - a) + y * a
 }
 
@@ -580,7 +580,7 @@ F: BaseFloat,
 B: GenBType,
 T: NumBoolRel<F, B>
 >(x: T, y: T, a: B) -> T {
-    let ling = <F as Zero>::zero();
+    let ling = F::zero();
     x.zip_bool(&a, |f, b| -> F {
         if b {
             ling
@@ -610,9 +610,9 @@ T: NumBoolRel<F, B>
 pub fn step<F: BaseFloat, T: GenFloat<F>>(edge: T, x: T) -> T {
     x.zip(edge, |f, e| -> F {
         if f < e {
-            <F as Zero>::zero()
+            F::zero()
         } else {
-            <F as One>::one()
+            F::one()
         }
     })
 }
@@ -634,9 +634,9 @@ pub fn step<F: BaseFloat, T: GenFloat<F>>(edge: T, x: T) -> T {
 pub fn step_s<F: BaseFloat, T: GenFloatVec<F>>(edge: F, x: T) -> T {
     x.map(|f| -> F {
         if f < edge {
-            <F as Zero>::zero()
+            F::zero()
         } else {
-            <F as One>::one()
+            F::one()
         }
     })
 }
@@ -662,8 +662,8 @@ pub fn step_s<F: BaseFloat, T: GenFloatVec<F>>(edge: F, x: T) -> T {
 /// ```
 #[inline]
 pub fn smoothstep<F: BaseFloat, T: GenFloat<F>>(edge0: T, edge1: T, x: T) -> T {
-    let ling = <T as Zero>::zero();
-    let yi = <T as One>::one();
+    let ling = T::zero();
+    let yi = T::one();
     let er = yi + yi;
     let san = er + yi;
 
@@ -682,8 +682,8 @@ pub fn smoothstep_s
 F: BaseFloat + GenNum<F>,
 T: GenFloatVec<F>
 >(edge0: F, edge1: F, x: T) -> T {
-    let ling = <F as Zero>::zero();
-    let yi = <F as One>::one();
+    let ling = F::zero();
+    let yi = F::one();
     let er = yi + yi;
     let san = er + yi;
 
@@ -698,13 +698,16 @@ T: GenFloatVec<F>
 /// # Example
 ///
 /// ```
-/// # #![feature(std_misc)]
+/// # extern crate glm;
+/// # extern crate num;
+/// # fn main() {
 /// use glm::{ bvec3, dvec3, isnan };
-/// use std::num::Float;
+/// use num::Float;
 ///
 /// let nan: f64 = Float::nan();
 /// assert!(isnan(nan));
 /// assert_eq!(isnan(dvec3(nan, 1., -0.)), bvec3(true, false, false));
+/// # }
 /// ```
 #[inline(always)]
 pub fn isnan<F: BaseFloat, B: GenBType, T: NumBoolRel<F, B>>(x: T) -> B {
@@ -717,12 +720,15 @@ pub fn isnan<F: BaseFloat, B: GenBType, T: NumBoolRel<F, B>>(x: T) -> B {
 /// # Example
 ///
 /// ```
-/// # #![feature(std_misc)]
-/// use std::num::Float;
+/// # extern crate glm;
+/// # extern crate num;
+/// # fn main() {
+/// use num::Float;
 ///
 /// let inf: f32 = Float::infinity();
 /// assert!(glm::isinf(inf));
 /// assert_eq!(glm::isinf(glm::vec2(inf, 0.)), glm::bvec2(true, false));
+/// # }
 /// ```
 #[inline(always)]
 pub fn isinf<F: BaseFloat, B: GenBType, T: NumBoolRel<F, B>>(x: T) -> B {
@@ -737,9 +743,11 @@ pub fn isinf<F: BaseFloat, B: GenBType, T: NumBoolRel<F, B>>(x: T) -> B {
 /// # Example
 ///
 /// ```
-/// # #![feature(std_misc)]
+/// # extern crate glm;
+/// # extern crate num;
+/// # fn main() {
 /// use glm::*;
-/// use std::num::Float;
+/// use num::Float;
 ///
 /// let f = 1_f32;
 /// let i = floatBitsToInt(f);
@@ -747,6 +755,7 @@ pub fn isinf<F: BaseFloat, B: GenBType, T: NumBoolRel<F, B>>(x: T) -> B {
 /// let inf: f32 = Float::infinity();
 /// let v = vec3(0.2, 0., inf);
 /// assert_eq!(floatBitsToInt(v), ivec3(0x3E4CCCCD, 0, 0x7f800000));
+/// # }
 /// ```
 #[inline(always)]
 #[allow(non_snake_case)]
@@ -765,9 +774,11 @@ pub fn floatBitsToInt<G: GenIType, T: FloatIntRel<f32, i32, G>>(value: T) -> G {
 /// # Example
 ///
 /// ```
-/// # #![feature(std_misc)]
+/// # extern crate glm;
+/// # extern crate num;
+/// # fn main() {
 /// use glm::{ floatBitsToUint, vec3, uvec3 };
-/// use std::num::Float;
+/// use num::Float;
 ///
 /// let f = 1_f32;
 /// let u = floatBitsToUint(f);
@@ -775,6 +786,7 @@ pub fn floatBitsToInt<G: GenIType, T: FloatIntRel<f32, i32, G>>(value: T) -> G {
 /// let inf: f32 = Float::infinity();
 /// let v = vec3(0.2, 0., inf);
 /// assert_eq!(floatBitsToUint(v), uvec3(0x3E4CCCCD, 0, 0x7f800000));
+/// # }
 /// ```
 #[inline(always)]
 #[allow(non_snake_case)]
@@ -791,9 +803,11 @@ pub fn floatBitsToUint<G: GenUType, T: FloatIntRel<f32, u32, G>>(value: T) -> G 
 /// # Example
 ///
 /// ```
-/// # #![feature(std_misc)]
+/// # extern crate glm;
+/// # extern crate num;
+/// # fn main() {
 /// use glm::{ intBitsToFloat, vec3, ivec3 };
-/// use std::num::Float;
+/// use num::Float;
 ///
 /// let i: i32 = 0x3F800000;
 /// let f = intBitsToFloat(i);
@@ -802,6 +816,7 @@ pub fn floatBitsToUint<G: GenUType, T: FloatIntRel<f32, u32, G>>(value: T) -> G 
 /// let vi = ivec3(0x3E4CCCCD, 0, 0x7f800000);
 /// let vf = vec3(0.2, 0., inf);
 /// assert_eq!(intBitsToFloat(vi), vf);
+/// # }
 /// ```
 #[inline(always)]
 #[allow(non_snake_case)]
@@ -818,9 +833,11 @@ pub fn intBitsToFloat<G: GenType, T: IntFloatRel<i32, f32, G>>(value: T) -> G {
 /// # Example
 ///
 /// ```
-/// # #![feature(std_misc)]
+/// # extern crate glm;
+/// # extern crate num;
+/// # fn main() {
 /// use glm::{ uintBitsToFloat, vec3, uvec3 };
-/// use std::num::Float;
+/// use num::Float;
 ///
 /// let i: u32 = 0x3F800000;
 /// let f = uintBitsToFloat(i);
@@ -829,6 +846,7 @@ pub fn intBitsToFloat<G: GenType, T: IntFloatRel<i32, f32, G>>(value: T) -> G {
 /// let vu = uvec3(0x3E4CCCCD, 0, 0x7f800000);
 /// let vf = vec3(0.2, 0., inf);
 /// assert_eq!(uintBitsToFloat(vu), vf);
+/// # }
 /// ```
 #[inline(always)]
 #[allow(non_snake_case)]
@@ -891,7 +909,7 @@ I: GenIType,
 T: FloatIntRel<F, i32, I>
 >(x: T) -> (T, I) {
     x.split_int(|f| -> (F, i32) {
-        let (s, e) = Float::frexp(f);
+        let (s, e) = BaseFloat::frexp(f);
         (s, e as i32)
     })
 }
@@ -921,6 +939,6 @@ G: GenFloat<F>,
 T: IntFloatRel<i32, F, G>
 >(x: G, exp: T) -> G {
     exp.zip_flt(&x, |i, f| -> F {
-        Float::ldexp(f, i as isize)
+        BaseFloat::ldexp(f, i as isize)
     })
 }

--- a/src/builtin/exp.rs
+++ b/src/builtin/exp.rs
@@ -24,7 +24,7 @@
 
 use basenum::BaseFloat;
 use traits::GenFloat;
-use std::num::Float;
+use num::Float;
 
 /// Returns `x` raised to the `y` power, i.e., *x<sup>y</sup>*.
 ///
@@ -141,5 +141,5 @@ pub fn sqrt<F: BaseFloat, T: GenFloat<F>>(x: T) -> T {
 /// ```
 #[inline(always)]
 pub fn inversesqrt<F: BaseFloat, T: GenFloat<F>>(x: T) -> T {
-    x.map(Float::rsqrt)
+    x.map(BaseFloat::rsqrt)
 }

--- a/src/builtin/geom.rs
+++ b/src/builtin/geom.rs
@@ -29,8 +29,7 @@
 use basenum::BaseFloat;
 use vec::traits::GenFloatVec;
 use vec::vec::Vector3;
-use std::num::Float;
-use num::{ One, Zero };
+use num::{ Float, One, Zero };
 
 /// Returns the dot product of `x` and `y`, i.e.,
 /// `x[0] * y[0] + x[1] * y[1] + ...`.
@@ -95,7 +94,7 @@ pub fn distance<S: BaseFloat, T: GenFloatVec<S>>(p0: T, p1: T) -> S {
 #[inline]
 #[allow(non_snake_case)]
 pub fn faceforward<S: BaseFloat, T: GenFloatVec<S>>(N: T, I: T, Nref: T) -> T {
-    let ling = <S as Zero>::zero();
+    let ling = S::zero();
     if dot(Nref, I) < ling {
         N
     } else {
@@ -135,12 +134,12 @@ pub fn reflect<S: BaseFloat, T: GenFloatVec<S>>(I: T, N: T) -> T {
 #[allow(non_snake_case)]
 pub fn refract<S: BaseFloat, T: GenFloatVec<S>>(I: T, N: T, eta: S) -> T {
     let dot_ni = dot(I, N);
-    let yi = <S as One>::one();
-    let ling = <S as Zero>::zero();
+    let yi = S::one();
+    let ling = S::zero();
 
     let k = yi - eta * eta * (yi - dot_ni) * dot_ni;
     if k < ling {
-        <T as Zero>::zero()
+        T::zero()
     } else {
         I * eta - N * (eta * dot_ni + k.sqrt())
     }

--- a/src/builtin/integer.rs
+++ b/src/builtin/integer.rs
@@ -26,8 +26,8 @@
 use basenum::BaseInt;
 use traits::{ GenNum, GenInt, GenIType, GenUType };
 use vec::vec::{ UVec2, UVec3, UVec4, IVec2, IVec3, IVec4 };
+use cast::PrimCast;
 use std::mem;
-use std::num::{ Int, cast };
 use num::Zero;
 
 // used by `findLSB` and `findMSB`.
@@ -190,11 +190,11 @@ pub fn bitfieldExtract
 I: BaseInt,
 T: GenInt<I>
 >(value: T, offset: usize, bits: usize) -> T {
-    let ling = <T as Zero>::zero();
+    let ling = T::zero();
     if value.is_zero() || bits == 0 || offset + bits > 32 {
         ling
     } else {
-        let mask: I = cast((1_u32 << bits) - 1).unwrap();
+        let mask = I::from((1_u32 << bits) - 1).unwrap();
         value.map(|i| -> I {
             (i >> offset) & mask
         })
@@ -229,7 +229,7 @@ T: GenInt<I>
     if bits == 0 {
         base
     } else {
-        let mask: I = cast(((1_u32 << bits) - 1) << offset).unwrap();
+        let mask = I::from(((1_u32 << bits) - 1) << offset).unwrap();
         base.zip(insert, |i, j| -> I {
             (i & !mask) | (j & mask)
         })
@@ -283,7 +283,7 @@ pub fn bitfieldReverse<I: BaseInt, T: GenInt<I>>(value: T) -> T {
 #[allow(non_snake_case)]
 pub fn bitCount<I: BaseInt, T: GenInt<I>>(value: T) -> T {
     value.map(|i| -> I {
-        let c: I = cast(i.count_ones()).unwrap();
+        let c = I::from(i.count_ones()).unwrap();
         c
     })
 }
@@ -342,7 +342,7 @@ I: GenIType,
 T: IntIntRel<B, I>
 >(value: T) -> I {
     value.map_int(|i| -> i32 {
-        let ling = <B as Zero>::zero();
+        let ling = B::zero();
         if i.is_zero() {
             -1
         } else if i < ling {

--- a/src/builtin/matrix.rs
+++ b/src/builtin/matrix.rs
@@ -80,8 +80,8 @@ C: GenFloatVec<T>,
 R: GenFloatVec<T>,
 M: GenMat<T, C, R = R>
 >(c: C, r: R) -> M {
-    let mut z = <M as Zero>::zero();
-    let dim = <R as GenVec<T>>::dim();
+    let mut z = M::zero();
+    let dim = R::dim();
     for i in 0..dim {
         z[i] = c * r[i];
     };

--- a/src/builtin/noise.rs
+++ b/src/builtin/noise.rs
@@ -46,8 +46,8 @@ use num::{ One, Zero };
 #[allow(non_snake_case)]
 pub fn grad4(j: f32, ip: Vec4) -> Vec4 {
     let mut pXYZ = floor(fract(vec3(j, j, j) * ip.truncate(3)) * 7.) * ip[2] - 1.;
-    let pW = 1.5 - dot(abs(pXYZ), <Vec3 as One>::one());
-    let s = to_vec4(lessThan(vec4(pXYZ.x, pXYZ.y, pXYZ.z, pW), <Vec4 as Zero>::zero()));
+    let pW = 1.5 - dot(abs(pXYZ), Vec3::one());
+    let s = to_vec4(lessThan(vec4(pXYZ.x, pXYZ.y, pXYZ.z, pW), Vec4::zero()));
     pXYZ = pXYZ + (s.truncate(3) * 2. - 1.) * s.w;
     vec4(pXYZ.x, pXYZ.y, pXYZ.z, pW)
 }
@@ -80,7 +80,7 @@ impl NoiseImpl for f32 {
 
 impl NoiseImpl for Vec2 {
     fn noise1(self) -> f32 {
-        let yi = <Vec2 as One>::one();
+        let yi = Vec2::one();
         let C = vec4(
              0.211324865405187,     //  (3.0 -  sqrt(3.0)) / 6.0
              0.366025403784439,     //  0.5 * (sqrt(3.0)  - 1.0)
@@ -143,7 +143,7 @@ impl NoiseImpl for Vec2 {
 
 impl NoiseImpl for Vec3 {
     fn noise1(self) -> f32 {
-        let yi = <Vec3 as One>::one();
+        let yi = Vec3::one();
         let C = vec2(1./6., 1./3.);
         let D = vec4(0., 0.5, 1., 2.);
 
@@ -184,7 +184,7 @@ impl NoiseImpl for Vec3 {
 
         let x = x_ * ns.x + ns.y;
         let y = y_ * ns.x + ns.y;
-        let h = <Vec4 as One>::one() - abs(x) - abs(y);
+        let h = Vec4::one() - abs(x) - abs(y);
 
         let b0 = vec4(x.x, x.y, y.x, y.y);
         let b1 = vec4(x.z, x.w, y.z, y.w);
@@ -193,7 +193,7 @@ impl NoiseImpl for Vec3 {
         // vec4 s1 = vec4(lessThan(b1,0.0))*2.0 - 1.0;
         let s0 = floor(b0) * 2. + 1.;
         let s1 = floor(b1) * 2. + 1.;
-        let sh = -step(h, <Vec4 as Zero>::zero());
+        let sh = -step(h, Vec4::zero());
 
         let a0 = vec4(b0.x, b0.z, b0.y, b0.w) + vec4(s0.x, s0.z, s0.y, s0.w) * vec4(sh.x, sh.x, sh.y, sh.y);
         let a1 = vec4(b1.x, b1.z, b1.y, b1.w) + vec4(s1.x, s1.z, s1.y, s1.w) * vec4(sh.z, sh.z, sh.w, sh.w);
@@ -221,7 +221,7 @@ impl NoiseImpl for Vec3 {
 
 impl NoiseImpl for Vec4 {
     fn noise1(self) -> f32 {
-        let yi = <Vec4 as One>::one();
+        let yi = Vec4::one();
         let C = vec4(
              0.138196601125011,     // (5 - sqrt(5))/20  G4
              0.276393202250021,     // 2 * G4
@@ -322,14 +322,14 @@ pub fn noise2<T: GenType + NoiseImpl>(x: T) -> Vec2 {
 /// Returns a 3D noise value based on the input value `x`.
 #[inline]
 pub fn noise3<T: GenType + NoiseImpl>(x: T) -> Vec3 {
-    let yi = <T as One>::one();
+    let yi = T::one();
     vec3((x - yi).noise1(), x.noise1(), (x + yi).noise1())
 }
 
 /// Returns a 4D noise value based on the input value `x`.
 #[inline]
 pub fn noise4<T: GenType + NoiseImpl>(x: T) -> Vec4 {
-    let yi = <T as One>::one();
+    let yi = T::one();
     vec4(
         (x - yi).noise1(),
         x.noise1(),

--- a/src/builtin/trig.rs
+++ b/src/builtin/trig.rs
@@ -25,18 +25,18 @@
 
 use basenum::BaseFloat;
 use traits::GenFloat;
-use std::num::Float;
+use num::Float;
 
 /// Converts `degrees` to radians, i.e., `π/180 * degrees`.
 #[inline(always)]
 pub fn radians<F: BaseFloat, T: GenFloat<F>>(degrees: T) -> T {
-    degrees.map(Float::to_radians)
+    degrees.map(BaseFloat::to_radians)
 }
 
 /// Converts `radians` to degrees, i.e., `180/π * radians`.
 #[inline(always)]
 pub fn degrees<F: BaseFloat, T: GenFloat<F>>(radians: T) -> T {
-    radians.map(Float::to_degrees)
+    radians.map(BaseFloat::to_degrees)
 }
 
 /// The standard trigonometric sine function.

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -25,8 +25,7 @@ use basenum::Primitive;
 use vec::traits::GenVec;
 use vec::vec::*;
 use std::default::Default;
-use std::num::ToPrimitive;
-use num::Zero;
+use num::{ ToPrimitive, Zero };
 
 /// This trait is like the `std::num::ToPrimitive`, but function `to_bool()`
 /// is added.
@@ -188,7 +187,7 @@ macro_rules! impl_ToScalar_for_scalar {
             impl<T: PrimCast> ToScalar<$t, T> for $t {
                 #[inline(always)]
                 fn to(self) -> Option<T> {
-                    <T as PrimCast>::from(self)
+                    T::from(self)
                 }
             }
         )+
@@ -203,7 +202,7 @@ macro_rules! impl_ToScalar_for_vector {
             impl<F: PrimCast, T: PrimCast> ToScalar<F, T> for $t<F> {
                 #[inline(always)]
                 fn to(self) -> Option<T> {
-                    <T as PrimCast>::from(self[0])
+                    T::from(self[0])
                 }
             }
         )+
@@ -285,7 +284,7 @@ macro_rules! impl_ToVector_for_vector {
             impl<F: PrimCast, T: PrimCast + Default> ToVector<F, T, $v<T>> for $v<F> {
                 #[inline]
                 fn to(self) -> Option<$v<T>> {
-                    let os = [$(<T as PrimCast>::from(self.$field)),+];
+                    let os = [$(T::from(self.$field)),+];
                     if os.iter().any(|&o| -> bool { o.is_none() }) {
                         None
                     } else {

--- a/src/ext/common.rs
+++ b/src/ext/common.rs
@@ -23,7 +23,7 @@
 
 use basenum::BaseFloat;
 use traits::GenFloat;
-use std::num::Float;
+use num::Float;
 
 /// Returns the reciprocal (inverse) of float number `x`.
 ///

--- a/src/ext/consts.rs
+++ b/src/ext/consts.rs
@@ -60,110 +60,110 @@ macro_rules! impl_Consts_for {
             impl<T> Consts<$bt> for T where T: GenFloat<$bt> {
                 #[inline(always)]
                 fn epsilon() -> T {
-                    GenNum::<$bt>::from_s(BaseFloat::epsilon())
+                    T::from_s(BaseFloat::epsilon())
                 }
                 #[inline(always)]
                 fn pi() -> T {
-                    GenNum::<$bt>::from_s(3.14159265358979323846264338327950288)
+                    T::from_s(3.14159265358979323846264338327950288)
                 }
                 #[inline(always)]
                 fn tau() -> T {
-                    GenNum::<$bt>::from_s(6.28318530717958647692528676655900576)
+                    T::from_s(6.28318530717958647692528676655900576)
                 }
                 #[inline(always)]
                 fn root_pi() -> T {
-                    GenNum::<$bt>::from_s(1.772453850905516027)
+                    T::from_s(1.772453850905516027)
                 }
                 #[inline(always)]
                 fn half_pi() -> T {
-                    GenNum::<$bt>::from_s(1.57079632679489661923132169163975144)
+                    T::from_s(1.57079632679489661923132169163975144)
                 }
                 #[inline(always)]
                 fn one_third_pi() -> T {
-                    GenNum::<$bt>::from_s(1.04719755119659774615421446109316763)
+                    T::from_s(1.04719755119659774615421446109316763)
                 }
                 #[inline(always)]
                 fn quarter_pi() -> T {
-                    GenNum::<$bt>::from_s(0.785398163397448309615660845819875721)
+                    T::from_s(0.785398163397448309615660845819875721)
                 }
                 #[inline(always)]
                 fn one_over_pi() -> T {
-                    GenNum::<$bt>::from_s(0.318309886183790671537767526745028724)
+                    T::from_s(0.318309886183790671537767526745028724)
                 }
                 #[inline(always)]
                 fn one_over_tau() -> T {
-                    GenNum::<$bt>::from_s(0.159154943091895335768883763372514362)
+                    T::from_s(0.159154943091895335768883763372514362)
                 }
                 #[inline(always)]
                 fn two_over_pi() -> T {
-                    GenNum::<$bt>::from_s(0.636619772367581343075535053490057448)
+                    T::from_s(0.636619772367581343075535053490057448)
                 }
                 #[inline(always)]
                 fn four_over_pi() -> T {
-                    GenNum::<$bt>::from_s(1.273239544735162686151070106980114898)
+                    T::from_s(1.273239544735162686151070106980114898)
                 }
                 #[inline(always)]
                 fn two_over_root_pi() -> T {
-                    GenNum::<$bt>::from_s(1.12837916709551257389615890312154517)
+                    T::from_s(1.12837916709551257389615890312154517)
                 }
                 #[inline(always)]
                 fn one_over_root_two() -> T {
-                    GenNum::<$bt>::from_s(0.707106781186547524400844362104849039)
+                    T::from_s(0.707106781186547524400844362104849039)
                 }
                 #[inline(always)]
                 fn root_half_pi() -> T {
-                    GenNum::<$bt>::from_s(1.253314137315500251)
+                    T::from_s(1.253314137315500251)
                 }
                 #[inline(always)]
                 fn root_tau() -> T {
-                    GenNum::<$bt>::from_s(2.506628274631000502)
+                    T::from_s(2.506628274631000502)
                 }
                 #[inline(always)]
                 fn root_ln_four() -> T {
-                    GenNum::<$bt>::from_s(1.17741002251547469)
+                    T::from_s(1.17741002251547469)
                 }
                 #[inline(always)]
                 fn e() -> T {
-                    GenNum::<$bt>::from_s(2.71828182845904523536028747135266250)
+                    T::from_s(2.71828182845904523536028747135266250)
                 }
                 #[inline(always)]
                 fn euler() -> T {
-                    GenNum::<$bt>::from_s(0.577215664901532860606)
+                    T::from_s(0.577215664901532860606)
                 }
                 #[inline(always)]
                 fn root_two() -> T {
-                    GenNum::<$bt>::from_s(1.41421356237309504880168872420969808)
+                    T::from_s(1.41421356237309504880168872420969808)
                 }
                 #[inline(always)]
                 fn root_three() -> T {
-                    GenNum::<$bt>::from_s(1.73205080756887729352744634150587236)
+                    T::from_s(1.73205080756887729352744634150587236)
                 }
                 #[inline(always)]
                 fn root_five() -> T {
-                    GenNum::<$bt>::from_s(2.23606797749978969640917366873127623)
+                    T::from_s(2.23606797749978969640917366873127623)
                 }
                 #[inline(always)]
                 fn ln_two() -> T {
-                    GenNum::<$bt>::from_s(0.693147180559945309417232121458176568)
+                    T::from_s(0.693147180559945309417232121458176568)
                 }
                 #[inline(always)]
                 fn ln_ten() -> T {
-                    GenNum::<$bt>::from_s(2.30258509299404568401799145468436421)
+                    T::from_s(2.30258509299404568401799145468436421)
                 }
                 #[inline(always)]
                 fn ln_ln_two() -> T {
-                    GenNum::<$bt>::from_s(-0.3665129205816643)
+                    T::from_s(-0.3665129205816643)
                 }
                 #[inline(always)]
                 fn one_third() -> T {
-                    GenNum::<$bt>::from_s(0.3333333333333333333333333333333333333333)
+                    T::from_s(0.3333333333333333333333333333333333333333)
                 }
                 #[inline(always)]
                 fn two_thirds() -> T {
-                    GenNum::<$bt>::from_s(0.666666666666666666666666666666666666667)
+                    T::from_s(0.666666666666666666666666666666666666667)
                 }
                 fn golden_ratio() -> T {
-                    GenNum::<$bt>::from_s(1.61803398874989484820458683436563811)
+                    T::from_s(1.61803398874989484820458683436563811)
                 }
             }
         )+
@@ -178,7 +178,7 @@ impl_Consts_for! { f32, f64 }
 /// Returns the epsilon constant for floating point types.
 #[inline(always)]
 pub fn epsilon<F: BaseFloat, T: GenFloat<F>>() -> T {
-    GenNum::<F>::from_s(BaseFloat::epsilon())
+    T::from_s(BaseFloat::epsilon())
 }
 
 /// Returns the Archimedes' constant π.

--- a/src/ext/exp.rs
+++ b/src/ext/exp.rs
@@ -23,7 +23,7 @@
 
 use basenum::{ BaseNum, BaseFloat };
 use traits::{ GenNum, GenFloat };
-use std::num::Float;
+use num::Float;
 
 /// Returns the cubic root.
 #[inline(always)]

--- a/src/ext/geom.rs
+++ b/src/ext/geom.rs
@@ -85,10 +85,10 @@ pub fn normalize_to<F: BaseFloat, T: GenFloatVec<F>>(x: T, len: F) -> T {
 /// ```
 #[inline]
 pub fn projection<F: BaseFloat, T: GenFloatVec<F>>(x: T, y: T) -> T {
-    let ling = <F as Zero>::zero();
+    let ling = F::zero();
     let sqlen = sqlength(y);
     if sqlen.is_approx_eq(&ling) {
-        <T as Zero>::zero()
+        T::zero()
     } else {
         y * bif::dot(x, y) * sqlen.recip()
     }
@@ -108,7 +108,7 @@ pub fn projection<F: BaseFloat, T: GenFloatVec<F>>(x: T, y: T) -> T {
 /// ```
 #[inline(always)]
 pub fn is_perpendicular<F: BaseFloat, T: GenFloatVec<F>>(x: T, y: T) -> bool {
-    bif::dot(x, y).is_approx_eq(&<F as Zero>::zero())
+    bif::dot(x, y).is_approx_eq(&F::zero())
 }
 
 /// Returns angle between vectors `x` and `y`.
@@ -133,7 +133,7 @@ pub fn is_perpendicular<F: BaseFloat, T: GenFloatVec<F>>(x: T, y: T) -> bool {
 /// ```
 #[inline]
 pub fn angle<F: BaseFloat, T: GenFloatVec<F>>(x: T, y: T) -> F {
-    let ling = <F as Zero>::zero();
+    let ling = F::zero();
     let sqmag = bif::dot(x, x) * bif::dot(y, y);
     if sqmag.is_approx_eq(&ling) {
         ling

--- a/src/ext/matrix/mod.rs
+++ b/src/ext/matrix/mod.rs
@@ -43,8 +43,8 @@ mod transform;
 /// ```
 #[inline]
 pub fn trace<F: BaseFloat, C: GenFloatVec<F>, M: GenSquareMat<F, C>>(m: &M) -> F {
-    let s = <C as GenVec<F>>::dim();
-    let mut tr = <F as Zero>::zero();
+    let s = C::dim();
+    let mut tr = F::zero();
     for i in 0..s {
         tr = tr + m[i][i];
     };
@@ -70,6 +70,6 @@ pub fn is_invertible
 <
 F: BaseFloat, C: GenFloatVec<F>, M: GenSquareMat<F, C>
 >(m: &M) -> bool {
-    let y = <F as Zero>::zero();
+    let y = F::zero();
     !m.determinant().is_approx_eq(&y)
 }

--- a/src/ext/trig.rs
+++ b/src/ext/trig.rs
@@ -23,7 +23,7 @@
 
 use basenum::BaseFloat;
 use traits::GenFloat;
-use std::num::Float;
+use num::Float;
 
 /// Simultaneously computes the sine and cosine of `x`, returns
 /// `(sin(x), cos(x))`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#![allow(unused_variables, deprecated)]
-#![feature(std_misc, core)]
+#![allow(unused_variables)]
+#![feature(std_misc)]
 
 //! GLSL mathematics for Rust programming language.
 //!
@@ -131,7 +131,7 @@ extern crate quickcheck;
 pub use builtin::*;
 
 pub use basenum::{
-    Primitive, BaseNum, Signed,
+    Primitive, BaseNum, SignedNum,
     ApproxEq, is_approx_eq, is_close_to
 };
 
@@ -173,6 +173,7 @@ pub use mat::ctor::{
 };
 
 pub use cast::{
+    PrimCast,
     int, uint, float, double, boolean,
     to_ivec2, to_ivec3, to_ivec4,
     to_uvec2, to_uvec3, to_uvec4,

--- a/src/mat/mat.rs
+++ b/src/mat/mat.rs
@@ -322,10 +322,11 @@ macro_rules! impl_matrix {
                 }
             }
             #[cfg(test)]
-            impl<T: BaseFloat + Arbitrary> Arbitrary for $t<T> {
+            impl<T: BaseFloat + Arbitrary> Arbitrary for $t<T>
+            where T::FromStrRadixErr: 'static {
                 #[inline]
                 fn arbitrary<G: Gen>(g: &mut G) -> $t<T> {
-                    $t { $($field: <$ct<T> as Arbitrary>::arbitrary(g)),+ }
+                    $t { $($field: $ct::<T>::arbitrary(g)),+ }
                 }
             }
             impl<T: BaseFloat> Add<T> for $t<T> {
@@ -422,7 +423,7 @@ macro_rules! impl_matrix {
             impl<T: BaseFloat> Zero for $t<T> {
                 #[inline(always)]
                 fn zero() -> $t<T> {
-                    $t { $($field: <$ct<T> as Zero>::zero()), + }
+                    $t { $($field: $ct::<T>::zero()), + }
                 }
                 #[inline(always)]
                 fn is_zero(&self) -> bool {

--- a/src/mat/sqmat.rs
+++ b/src/mat/sqmat.rs
@@ -25,14 +25,13 @@ use basenum::BaseFloat;
 use vec::vec::{ Vector2, Vector3, Vector4 };
 use super::traits::{ GenMat, GenSquareMat };
 use super::mat::*;
-use std::num::Float;
-use num::{ One, Zero };
+use num::{ Float, One, Zero };
 
 impl<T: BaseFloat> One for Matrix2<T> {
     #[inline]
     fn one() -> Matrix2<T> {
-        let y = <T as One>::one();
-        let l = <T as Zero>::zero();
+        let y = T::one();
+        let l = T::zero();
         Matrix2::new(
             Vector2::new(y, l),
             Vector2::new(l, y)
@@ -48,7 +47,7 @@ impl<T: BaseFloat> GenSquareMat<T, Vector2<T>> for Matrix2<T> {
     #[inline]
     fn inverse(&self) -> Option<Matrix2<T>> {
         let det = self.determinant();
-        let ling = <T as Zero>::zero();
+        let ling = T::zero();
         if det.is_approx_eq(&ling) {
             None
         } else {
@@ -65,8 +64,8 @@ impl<T: BaseFloat> GenSquareMat<T, Vector2<T>> for Matrix2<T> {
 impl<T: BaseFloat> One for Matrix3<T> {
     #[inline]
     fn one() -> Matrix3<T> {
-        let y = <T as One>::one();
-        let l = <T as Zero>::zero();
+        let y = T::one();
+        let l = T::zero();
         Matrix3::new(
             Vector3::new(y, l, l),
             Vector3::new(l, y, l),
@@ -85,7 +84,7 @@ impl<T: BaseFloat> GenSquareMat<T, Vector3<T>> for Matrix3<T> {
     #[inline]
     fn inverse(&self) -> Option<Matrix3<T>> {
         let det = self.determinant();
-        let ling = <T as Zero>::zero();
+        let ling = T::zero();
         if det.is_approx_eq(&ling) {
             None
         } else {
@@ -112,8 +111,8 @@ impl<T: BaseFloat> GenSquareMat<T, Vector3<T>> for Matrix3<T> {
 impl<T: BaseFloat> One for Matrix4<T> {
     #[inline]
     fn one() -> Matrix4<T> {
-        let y = <T as One>::one();
-        let l = <T as Zero>::zero();
+        let y = T::one();
+        let l = T::zero();
         Matrix4::new(
             Vector4::new(y, l, l, l),
             Vector4::new(l, y, l, l),
@@ -162,7 +161,7 @@ impl<T: BaseFloat> GenSquareMat<T, Vector4<T>> for Matrix4<T> {
     #[inline]
     fn inverse(&self) -> Option<Matrix4<T>> {
         let det = self.determinant();
-        let ling = <T as Zero>::zero();
+        let ling = T::zero();
         if det.is_approx_eq(&ling) {
             None
         } else {
@@ -223,7 +222,7 @@ mod test {
     fn test_determinant() {
         let m2 = mat2(4., 5., 6., 7.);
         assert_eq!(m2.determinant(), -2.);
-        assert_eq!(<Mat3 as One>::one().determinant(), 1.);
+        assert_eq!(Mat3::one().determinant(), 1.);
         let m4 = mat4(
             1., 0., 4., 0.,
             2., 1., 2., 1.,
@@ -232,14 +231,14 @@ mod test {
         );
         assert_eq!(m4.determinant(), -7.);
         assert_eq!((m4 * m4).determinant(), 49.);
-        assert_eq!(<Mat4 as One>::one().determinant(), 1.);
+        assert_eq!(Mat4::one().determinant(), 1.);
     }
 
     #[test]
     fn test_inverse_mat2() {
-        let yi = <Mat2 as One>::one();
+        let yi = Mat2::one();
         assert!(yi.inverse().is_some());
-        assert!(<DMat2 as Zero>::zero().inverse().is_none());
+        assert!(DMat2::zero().inverse().is_none());
         let mat = mat2(1., 3., 2., 4.);
         let inv = mat.inverse().unwrap();
         assert_close_to!(mat * inv, yi, 0.000001);
@@ -250,10 +249,10 @@ mod test {
 
     #[test]
     fn test_inverse_mat3() {
-        let yi = <Mat3 as One>::one();
+        let yi = Mat3::one();
         assert!(yi.inverse().is_some());
         assert_eq!(yi.inverse().unwrap(), yi);
-        assert!(<DMat3 as Zero>::zero().inverse().is_none());
+        assert!(DMat3::zero().inverse().is_none());
         let mat = mat3(5., 7., 11., -6., 9., 2., 1., 13., 0.);
         let inv = mat.inverse().unwrap();
         assert_close_to!(mat * inv, yi, 0.000001);
@@ -276,6 +275,6 @@ mod test {
         );
         assert_approx_eq!(mat.inverse().unwrap(), invm);
         assert_close_to!(mat.inverse().unwrap().inverse().unwrap(), mat, 0.000001);
-        assert!(<Mat4 as One>::one().inverse().is_some());
+        assert!(Mat4::one().inverse().is_some());
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -21,11 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use basenum::{ BaseNum, BaseInt, BaseFloat, ApproxEq, Signed };
-use std::num::Float;
+use basenum::{ BaseNum, BaseInt, BaseFloat, SignedNum, ApproxEq };
 use std::ops::{ Add, Mul, Sub, Div, Rem, Not, BitAnd, BitOr, BitXor, Shl, Shr };
 use rand::Rand;
-use num::{ One, Zero };
+use num::{ Float, One, Zero };
 
 // TODO: use associated types to reduce redundant type parameters.
 
@@ -45,8 +44,7 @@ pub trait GenNum<E: BaseNum>
     /// Constructs from a scalar number.
     fn from_s(x: E) -> Self;
 
-    fn map<F>(self, f: F) -> Self
-        where F: Fn(E) -> E;
+    fn map<F>(self, f: F) -> Self where F: Fn(E) -> E;
 
     fn zip<F>(self, y: Self, f: F) -> Self where F: Fn(E, E) -> E;
 
@@ -99,7 +97,7 @@ pub trait GenInt<I: BaseInt>
 /// # Note
 ///
 /// Only 32-bit integer is used in GLSL.
-pub trait GenIType: GenInt<i32> + Signed + Sub<i32, Output = Self> {}
+pub trait GenIType: GenInt<i32> + SignedNum + Sub<i32, Output = Self> {}
 
 impl_GenNum_for_scalar! { i32 }
 impl GenInt<i32> for i32 {}
@@ -120,7 +118,7 @@ impl GenUType for u32 {}
 pub trait GenFloat<F: BaseFloat>
 : GenNum<F>
 + ApproxEq<BaseType = F>
-+ Signed
++ SignedNum
 + Sub<F, Output = Self>
 {
     /// Computes and returns `a * b + c`.

--- a/src/vec/traits.rs
+++ b/src/vec/traits.rs
@@ -37,7 +37,7 @@ pub trait GenVec<T: Primitive>
     ///
     /// ```
     /// use glm::GenVec;    // bring the method into scope.
-    /// assert_eq!(<glm::IVec4 as GenVec<i32>>::dim(), 4);
+    /// assert_eq!(glm::IVec4::dim(), 4);
     /// ```
     fn dim() -> usize;
 

--- a/src/vec/vec.rs
+++ b/src/vec/vec.rs
@@ -26,13 +26,12 @@ use traits::*;
 use super::traits::{ GenVec, GenNumVec, GenFloatVec, GenBVec };
 use std::cmp::Eq;
 use std::mem;
-use std::num::Float;
 use std::ops::{
     Add, Mul, Sub, Neg, Div, Rem, Not, BitAnd, BitOr, BitXor, Shl, Shr,
     Index, IndexMut,
 };
 use rand::{ Rand, Rng };
-use num::{ One, Zero };
+use num::{ Float, One, Zero };
 use quickcheck::{ Arbitrary, Gen };
 
 // copied from `cgmath-rs/src/vector.rs`.
@@ -189,19 +188,19 @@ macro_rules! def_genvec(
         impl<T: BaseNum> One for $t<T> {
             #[inline(always)]
             fn one() -> $t<T> {
-                let y = <T as One>::one();
+                let y = T::one();
                 $t { $($field: y),+ }
             }
         }
         impl<T: BaseNum> Zero for $t<T> {
             #[inline(always)]
             fn zero() -> $t<T> {
-                let l = <T as Zero>::zero();
+                let l = T::zero();
                 $t { $($field: l),+ }
             }
             #[inline]
             fn is_zero(&self) -> bool {
-                let l = <T as Zero>::zero();
+                let l = T::zero();
                 $(self.$field == l) && +
             }
         }
@@ -220,9 +219,10 @@ macro_rules! def_genvec(
             }
             #[inline]
             fn split<F: Fn(T) -> (T, T)>(self, f: F) -> ($t<T>, $t<T>) {
-                let mut a = <$t<T> as Zero>::zero();
-                let mut b = <$t<T> as Zero>::zero();
-                let dim = <$t<T> as GenVec<T>>::dim();
+                let ling = $t::<T>::zero();
+                let mut a = ling;
+                let mut b = ling;
+                let dim = $t::<T>::dim();
                 for i in 0..dim {
                     let (c, d) = f(self[i]);
                     a[i] = c;
@@ -232,9 +232,10 @@ macro_rules! def_genvec(
             }
             #[inline]
             fn map2<F: Fn(T, T) -> (T, T)>(self, y: Self, f: F) -> (Self, Self) {
-                let mut a = <Self as Zero>::zero();
-                let mut b = <Self as Zero>::zero();
-                let dim = <Self as GenVec<T>>::dim();
+                let ling = Self::zero();
+                let mut a = ling;
+                let mut b = ling;
+                let dim = Self::dim();
                 for i in 0..dim {
                     let (c, d) = f(self[i], y[i]);
                     a[i] = c;
@@ -261,28 +262,28 @@ macro_rules! def_genvec(
                 fold!(max, { $(self.$field),+ })
             }
         }
-        impl<T: Signed + BaseNum> Neg for $t<T> {
+        impl<T: SignedNum + BaseNum> Neg for $t<T> {
             type Output = $t<T>;
             #[inline]
             fn neg(self) -> $t<T> {
                 $t::new($(-(self.$field)),+)
             }
         }
-        impl<T: Signed + BaseNum> Sub<$t<T>> for $t<T> {
+        impl<T: SignedNum + BaseNum> Sub<$t<T>> for $t<T> {
             type Output = $t<T>;
             #[inline(always)]
             fn sub(self, rhs: $t<T>) -> $t<T> {
                 $t::new($(self.$field - rhs.$field),+)
             }
         }
-        impl<T: Signed + BaseNum> Sub<T> for $t<T> {
+        impl<T: SignedNum + BaseNum> Sub<T> for $t<T> {
             type Output = $t<T>;
             #[inline(always)]
             fn sub(self, rhs: T) -> $t<T> {
                 $t::new($(self.$field - rhs),+)
             }
         }
-        impl<T: Signed + BaseNum> Signed for $t<T> {
+        impl<T: SignedNum + BaseNum> SignedNum for $t<T> {
             #[inline]
             fn abs(&self) -> $t<T> {
                 $t::new($(self.$field.abs()),+)
@@ -555,7 +556,7 @@ mod test {
             miv[0] = iv.x + 1;
             miv[1] = iv.y + 1;
             miv[2] = iv.z + 1;
-            miv == iv + <IVec3 as One>::one()
+            miv == iv + IVec3::one()
         }
         quickcheck(prop as fn(IVec3) -> bool);
     }


### PR DESCRIPTION
Summary of changes,
- Use `num::{ PrimInt, Float, Signed, ToPrimitive }` instead of `std::num::{ Int, Float, SignedInt, ToPrimitive }`,
- Rename `glm::Signed` to `glm::SignedNum`.
- Remove `#[feature(core)]`,`
- Define methods that are missing in `num::Float`, including `to_degrees`, `to_radians`, `rsqrt`, `frexp` and `ldexp`,
- Use `glm::cast::PrimCast::from` instead of `std::num::cast`,
- Export `glm::cast::PrimCast`,
- Do not use `range`,
- Do not use `<A as B>` syntax.