### PR TITLE
Fix E2077 warning.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "glm"
-version = "0.1.18"
+version = "0.2.0"
 authors = [
     "Che Kenan <chekenan@gmail.com>",
     "Nerijus Arlauskas <nercury@gmail.com>",

--- a/src/basenum.rs
+++ b/src/basenum.rs
@@ -70,7 +70,8 @@ pub trait BaseNum
 
 /// Trait for numerical types that have negative values.
 pub trait SignedNum
-: Neg<Output = Self>
+: Sized
++ Neg<Output = Self>
 + Sub<Self, Output = Self>
 {
     /// Returns the absolute value of the receiver.

--- a/src/builtin/matrix.rs
+++ b/src/builtin/matrix.rs
@@ -39,11 +39,11 @@ use num::Zero;
 /// # Example
 ///
 /// ```
-/// use glm::{ matrixCompMult, mat2x3 };
+/// use glm::{ matrixCompMult, mat3x2 };
 ///
-/// let m1 = mat2x3(1., 4., 2., 5., 3., 6.);
-/// let m2 = mat2x3(2., 3., 2., 3., 2., 3.);
-/// let me = mat2x3(2., 12., 4., 15., 6., 18.);
+/// let m1 = mat3x2(1., 4., 2., 5., 3., 6.);
+/// let m2 = mat3x2(2., 3., 2., 3., 2., 3.);
+/// let me = mat3x2(2., 12., 4., 15., 6., 18.);
 /// assert_eq!(matrixCompMult(&m1, &m2), me);
 /// ```
 #[inline(always)]
@@ -68,8 +68,8 @@ M: GenMat<T, C>
 /// # use glm::*;
 /// let v2 = vec2(1., 2.);
 /// let v3 = vec3(4., 0., -1.);
-/// let e = mat2x3(4., 8., 0., 0., -1., -2.);
-/// let op: Mat2x3 = outerProduct(v2, v3);
+/// let e = mat3x2(4., 8., 0., 0., -1., -2.);
+/// let op: Mat3x2 = outerProduct(v2, v3);
 /// assert_eq!(op, e);
 /// ```
 #[inline]
@@ -78,7 +78,17 @@ pub fn outerProduct<
 T: BaseFloat,
 C: GenFloatVec<T>,
 R: GenFloatVec<T>,
-M: GenMat<T, C, R = R>
+/*
+ * NOTE:
+ * I can't believe Rust allows this! But Rust is wrong at the first place.
+ * Associated types (e.g., `R` and `Transpose` of `GenMat` here) are not type
+ * parameters, and should not be mandatorily required when specifying a type,
+ * and if `Transpose` is ommitted (as we did before), that does not mean
+ * `GenMat` is not implemented for `Tanspose` of `M` (E0277). How could that
+ * be possible?
+ */
+N: GenMat<T, R, R = C, Transpose = M>,
+M: GenMat<T, C, R = R, Transpose = N>
 >(c: C, r: R) -> M {
     let mut z = M::zero();
     let dim = R::dim();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,10 +76,10 @@
 //!   instead a generic type.
 //!
 //!   See documentation of these functions for detail.
-//! - Most explicit conversion functions, like `vec2`, `dmat3x4` etc., do not
+//! - Most explicit conversion functions, like `vec2`, `dmat4x3` etc., do not
 //!   work, for the same reason as above.
 //!   This is rather inconvenient, and the plan is introducing functions like
-//!   `to_vec2`, `to_dmat3x4` in future version.
+//!   `to_vec2`, `to_dmat4x3` in future version.
 //! - No implicit conversion.
 //! - Explicit type conversion function `bool` is renamed to `boolean`.
 //! - Many explicit type conversion functions for vector types are introduced.
@@ -159,18 +159,18 @@ pub use mat::traits::{ GenMat, GenSquareMat };
 
 pub use mat::mat::{
     Matrix2, Matrix3, Matrix4,
-    Matrix2x3, Matrix2x4, Matrix3x2, Matrix3x4, Matrix4x2, Matrix4x3,
+    Matrix3x2, Matrix4x2, Matrix2x3, Matrix4x3, Matrix2x4, Matrix3x4,
     Mat2, Mat3, Mat4,
-    Mat2x3, Mat3x2, Mat2x4, Mat4x2, Mat3x4, Mat4x3,
+    Mat3x2, Mat2x3, Mat4x2, Mat2x4, Mat4x3, Mat3x4,
     DMat2, DMat3, DMat4,
-    DMat2x3, DMat3x2, DMat2x4, DMat4x2, DMat3x4, DMat4x3,
+    DMat3x2, DMat2x3, DMat4x2, DMat2x4, DMat4x3, DMat3x4,
 };
 
 pub use mat::ctor::{
     mat2, mat3, mat4,
-    mat2x3, mat3x2, mat2x4, mat4x2, mat3x4, mat4x3,
+    mat3x2, mat2x3, mat4x2, mat2x4, mat4x3, mat3x4,
     dmat2, dmat3, dmat4,
-    dmat2x3, dmat3x2, dmat2x4, dmat4x2, dmat3x4, dmat4x3,
+    dmat3x2, dmat2x3, dmat4x2, dmat2x4, dmat4x3, dmat3x4,
 };
 
 pub use cast::{

--- a/src/mat/ctor.rs
+++ b/src/mat/ctor.rs
@@ -36,12 +36,12 @@ pub fn mat2(
 }
 
 #[inline]
-pub fn mat2x3(
+pub fn mat3x2(
     m11: f32, m21: f32,
     m12: f32, m22: f32,
     m13: f32, m23: f32
-) -> Mat2x3 {
-    Matrix2x3 {
+) -> Mat3x2 {
+    Matrix3x2 {
         c0: vec2(m11, m21),
         c1: vec2(m12, m22),
         c2: vec2(m13, m23)
@@ -49,13 +49,13 @@ pub fn mat2x3(
 }
 
 #[inline]
-pub fn mat2x4(
+pub fn mat4x2(
     m11: f32, m21: f32,
     m12: f32, m22: f32,
     m13: f32, m23: f32,
     m14: f32, m24: f32
-) -> Mat2x4 {
-    Matrix2x4 {
+) -> Mat4x2 {
+    Matrix4x2 {
         c0: vec2(m11, m21),
         c1: vec2(m12, m22),
         c2: vec2(m13, m23),
@@ -77,24 +77,24 @@ pub fn mat3(
 }
 
 #[inline]
-pub fn mat3x2(
+pub fn mat2x3(
     m11: f32, m21: f32, m31: f32,
     m12: f32, m22: f32, m32: f32
-) -> Mat3x2 {
-    Matrix3x2 {
+) -> Mat2x3 {
+    Matrix2x3 {
         c0: vec3(m11, m21, m31),
         c1: vec3(m12, m22, m32)
     }
 }
 
 #[inline]
-pub fn mat3x4(
+pub fn mat4x3(
     m11: f32, m21: f32, m31: f32,
     m12: f32, m22: f32, m32: f32,
     m13: f32, m23: f32, m33: f32,
     m14: f32, m24: f32, m34: f32
-) -> Mat3x4 {
-    Matrix3x4 {
+) -> Mat4x3 {
+    Matrix4x3 {
         c0: vec3(m11, m21, m31),
         c1: vec3(m12, m22, m32),
         c2: vec3(m13, m23, m33),
@@ -118,23 +118,23 @@ pub fn mat4(
 }
 
 #[inline]
-pub fn mat4x2(
+pub fn mat2x4(
     m11: f32, m21: f32, m31: f32, m41: f32,
     m12: f32, m22: f32, m32: f32, m42: f32,
-) -> Mat4x2 {
-    Matrix4x2 {
+) -> Mat2x4 {
+    Matrix2x4 {
         c0: vec4(m11, m21, m31, m41),
         c1: vec4(m12, m22, m32, m42)
     }
 }
 
 #[inline]
-pub fn mat4x3(
+pub fn mat3x4(
     m11: f32, m21: f32, m31: f32, m41: f32,
     m12: f32, m22: f32, m32: f32, m42: f32,
     m13: f32, m23: f32, m33: f32, m43: f32
-) -> Mat4x3 {
-    Matrix4x3 {
+) -> Mat3x4 {
+    Matrix3x4 {
         c0: vec4(m11, m21, m31, m41),
         c1: vec4(m12, m22, m32, m42),
         c2: vec4(m13, m23, m33, m43)
@@ -153,12 +153,12 @@ pub fn dmat2(
 }
 
 #[inline]
-pub fn dmat2x3(
+pub fn dmat3x2(
     m11: f64, m21: f64,
     m12: f64, m22: f64,
     m13: f64, m23: f64
-) -> DMat2x3 {
-    Matrix2x3 {
+) -> DMat3x2 {
+    Matrix3x2 {
         c0: dvec2(m11, m21),
         c1: dvec2(m12, m22),
         c2: dvec2(m13, m23)
@@ -166,13 +166,13 @@ pub fn dmat2x3(
 }
 
 #[inline]
-pub fn dmat2x4(
+pub fn dmat4x2(
     m11: f64, m21: f64,
     m12: f64, m22: f64,
     m13: f64, m23: f64,
     m14: f64, m24: f64
-) -> DMat2x4 {
-    Matrix2x4 {
+) -> DMat4x2 {
+    Matrix4x2 {
         c0: dvec2(m11, m21),
         c1: dvec2(m12, m22),
         c2: dvec2(m13, m23),
@@ -194,24 +194,24 @@ pub fn dmat3(
 }
 
 #[inline]
-pub fn dmat3x2(
+pub fn dmat2x3(
     m11: f64, m21: f64, m31: f64,
     m12: f64, m22: f64, m32: f64
-) -> DMat3x2 {
-    Matrix3x2 {
+) -> DMat2x3 {
+    Matrix2x3 {
         c0: dvec3(m11, m21, m31),
         c1: dvec3(m12, m22, m32)
     }
 }
 
 #[inline]
-pub fn dmat3x4(
+pub fn dmat4x3(
     m11: f64, m21: f64, m31: f64,
     m12: f64, m22: f64, m32: f64,
     m13: f64, m23: f64, m33: f64,
     m14: f64, m24: f64, m34: f64
-) -> DMat3x4 {
-    Matrix3x4 {
+) -> DMat4x3 {
+    Matrix4x3 {
         c0: dvec3(m11, m21, m31),
         c1: dvec3(m12, m22, m32),
         c2: dvec3(m13, m23, m33),
@@ -235,23 +235,23 @@ pub fn dmat4(
 }
 
 #[inline]
-pub fn dmat4x2(
+pub fn dmat2x4(
     m11: f64, m21: f64, m31: f64, m41: f64,
     m12: f64, m22: f64, m32: f64, m42: f64,
-) -> DMat4x2 {
-    Matrix4x2 {
+) -> DMat2x4 {
+    Matrix2x4 {
         c0: dvec4(m11, m21, m31, m41),
         c1: dvec4(m12, m22, m32, m42)
     }
 }
 
 #[inline]
-pub fn dmat4x3(
+pub fn dmat3x4(
     m11: f64, m21: f64, m31: f64, m41: f64,
     m12: f64, m22: f64, m32: f64, m42: f64,
     m13: f64, m23: f64, m33: f64, m43: f64
-) -> DMat4x3 {
-    Matrix4x3 {
+) -> DMat3x4 {
+    Matrix3x4 {
         c0: dvec4(m11, m21, m31, m41),
         c1: dvec4(m12, m22, m32, m42),
         c2: dvec4(m13, m23, m33, m43)

--- a/src/mat/mat.rs
+++ b/src/mat/mat.rs
@@ -129,19 +129,19 @@ macro_rules! transpose_unrolled {
         )
     };
     ($m: ident, Vector2, Vector3) => {
-        Matrix3x2::new(
+        Matrix2x3::new(
             Vector3::new($m[0][0], $m[1][0], $m[2][0]),
             Vector3::new($m[0][1], $m[1][1], $m[2][1])
         )
     };
     ($m: ident, Vector2, Vector4) => {
-        Matrix4x2::new(
+        Matrix2x4::new(
             Vector4::new($m[0][0], $m[1][0], $m[2][0], $m[3][0]),
             Vector4::new($m[0][1], $m[1][1], $m[2][1], $m[3][1])
         )
     };
     ($m: ident, Vector3, Vector2) => {
-        Matrix2x3::new(
+        Matrix3x2::new(
             Vector2::new($m[0][0], $m[1][0]),
             Vector2::new($m[0][1], $m[1][1]),
             Vector2::new($m[0][2], $m[1][2])
@@ -155,14 +155,14 @@ macro_rules! transpose_unrolled {
         )
     };
     ($m: ident, Vector3, Vector4) => {
-        Matrix4x3::new(
+        Matrix3x4::new(
             Vector4::new($m[0][0], $m[1][0], $m[2][0], $m[3][0]),
             Vector4::new($m[0][1], $m[1][1], $m[2][1], $m[3][1]),
             Vector4::new($m[0][2], $m[1][2], $m[2][2], $m[3][2])
         )
     };
     ($m: ident, Vector4, Vector2) => {
-        Matrix2x4::new(
+        Matrix4x2::new(
             Vector2::new($m[0][0], $m[1][0]),
             Vector2::new($m[0][1], $m[1][1]),
             Vector2::new($m[0][2], $m[1][2]),
@@ -170,7 +170,7 @@ macro_rules! transpose_unrolled {
         )
     };
     ($m: ident, Vector4, Vector3) => {
-        Matrix3x4::new(
+        Matrix4x3::new(
             Vector3::new($m[0][0], $m[1][0], $m[2][0]),
             Vector3::new($m[0][1], $m[1][1], $m[2][1]),
             Vector3::new($m[0][2], $m[1][2], $m[2][2]),
@@ -205,15 +205,15 @@ macro_rules! def_matrix {
 
 def_matrix! {
     { Matrix2,   Vector2, c0, c1 },
-    { Matrix2x3, Vector2, c0, c1, c2 },
-    { Matrix2x4, Vector2, c0, c1, c2, c3 },
+    { Matrix3x2, Vector2, c0, c1, c2 },
+    { Matrix4x2, Vector2, c0, c1, c2, c3 },
 
-    { Matrix3x2, Vector3, c0, c1 },
+    { Matrix2x3, Vector3, c0, c1 },
     { Matrix3,   Vector3, c0, c1, c2 },
-    { Matrix3x4, Vector3, c0, c1, c2, c3 },
+    { Matrix4x3, Vector3, c0, c1, c2, c3 },
 
-    { Matrix4x2, Vector4, c0, c1 },
-    { Matrix4x3, Vector4, c0, c1, c2 },
+    { Matrix2x4, Vector4, c0, c1 },
+    { Matrix3x4, Vector4, c0, c1, c2 },
     { Matrix4,   Vector4, c0, c1, c2, c3 }
 }
 
@@ -448,15 +448,15 @@ macro_rules! impl_matrix {
 
 impl_matrix! {
     { Matrix2,   Vector2, Vector2, Matrix2,   Matrix2, 2, c0, c1 },
-    { Matrix2x3, Vector2, Vector3, Matrix3x2, Matrix2, 3, c0, c1, c2 },
-    { Matrix2x4, Vector2, Vector4, Matrix4x2, Matrix2, 4, c0, c1, c2, c3 },
+    { Matrix3x2, Vector2, Vector3, Matrix2x3, Matrix2, 3, c0, c1, c2 },
+    { Matrix4x2, Vector2, Vector4, Matrix2x4, Matrix2, 4, c0, c1, c2, c3 },
 
-    { Matrix3x2, Vector3, Vector2, Matrix2x3, Matrix3, 2, c0, c1 },
+    { Matrix2x3, Vector3, Vector2, Matrix3x2, Matrix3, 2, c0, c1 },
     { Matrix3,   Vector3, Vector3, Matrix3,   Matrix3, 3, c0, c1, c2 },
-    { Matrix3x4, Vector3, Vector4, Matrix4x3, Matrix3, 4, c0, c1, c2, c3 },
+    { Matrix4x3, Vector3, Vector4, Matrix3x4, Matrix3, 4, c0, c1, c2, c3 },
 
-    { Matrix4x2, Vector4, Vector2, Matrix2x4, Matrix4, 2, c0, c1 },
-    { Matrix4x3, Vector4, Vector3, Matrix3x4, Matrix4, 3, c0, c1, c2 },
+    { Matrix2x4, Vector4, Vector2, Matrix4x2, Matrix4, 2, c0, c1 },
+    { Matrix3x4, Vector4, Vector3, Matrix4x3, Matrix4, 3, c0, c1, c2 },
     { Matrix4,   Vector4, Vector4, Matrix4,   Matrix4, 4, c0, c1, c2, c3 }
 }
 
@@ -479,32 +479,32 @@ macro_rules! impl_mul(
 );
 
 impl_mul! {
-    { Matrix3x2, Matrix2,   Matrix3x2, c0, c1 },
-    { Matrix4x2, Matrix2,   Matrix4x2, c0, c1 },
+    { Matrix2x3, Matrix2,   Matrix2x3, c0, c1 },
+    { Matrix2x4, Matrix2,   Matrix2x4, c0, c1 },
 
-    { Matrix2,   Matrix2x3, Matrix2x3, c0, c1, c2 },
-    { Matrix4x2, Matrix2x3, Matrix4x3, c0, c1, c2 },
+    { Matrix2,   Matrix3x2, Matrix3x2, c0, c1, c2 },
+    { Matrix2x4, Matrix3x2, Matrix3x4, c0, c1, c2 },
 
-    { Matrix2,   Matrix2x4, Matrix2x4, c0, c1, c2, c3 },
-    { Matrix3x2, Matrix2x4, Matrix3x4, c0, c1, c2, c3 },
+    { Matrix2,   Matrix4x2, Matrix4x2, c0, c1, c2, c3 },
+    { Matrix2x3, Matrix4x2, Matrix4x3, c0, c1, c2, c3 },
 
-    { Matrix3,   Matrix3x2, Matrix3x2, c0, c1 },
-    { Matrix4x3, Matrix3x2, Matrix4x2, c0, c1 },
+    { Matrix3,   Matrix2x3, Matrix2x3, c0, c1 },
+    { Matrix3x4, Matrix2x3, Matrix2x4, c0, c1 },
 
-    { Matrix2x3, Matrix3,   Matrix2x3, c0, c1, c2 },
-    { Matrix4x3, Matrix3,   Matrix4x3, c0, c1, c2 },
+    { Matrix3x2, Matrix3,   Matrix3x2, c0, c1, c2 },
+    { Matrix3x4, Matrix3,   Matrix3x4, c0, c1, c2 },
 
-    { Matrix2x3, Matrix3x4, Matrix2x4, c0, c1, c2, c3 },
-    { Matrix3,   Matrix3x4, Matrix3x4, c0, c1, c2, c3 },
+    { Matrix3x2, Matrix4x3, Matrix4x2, c0, c1, c2, c3 },
+    { Matrix3,   Matrix4x3, Matrix4x3, c0, c1, c2, c3 },
 
-    { Matrix3x4, Matrix4x2, Matrix3x2, c0, c1 },
-    { Matrix4,   Matrix4x2, Matrix4x2, c0, c1 },
+    { Matrix4x3, Matrix2x4, Matrix2x3, c0, c1 },
+    { Matrix4,   Matrix2x4, Matrix2x4, c0, c1 },
 
-    { Matrix2x4, Matrix4x3, Matrix2x3, c0, c1, c2 },
-    { Matrix4,   Matrix4x3, Matrix4x3, c0, c1, c2 },
+    { Matrix4x2, Matrix3x4, Matrix3x2, c0, c1, c2 },
+    { Matrix4,   Matrix3x4, Matrix3x4, c0, c1, c2 },
 
-    { Matrix2x4, Matrix4,   Matrix2x4, c0, c1, c2, c3 },
-    { Matrix3x4, Matrix4,   Matrix3x4, c0, c1, c2, c3 }
+    { Matrix4x2, Matrix4,   Matrix4x2, c0, c1, c2, c3 },
+    { Matrix4x3, Matrix4,   Matrix4x3, c0, c1, c2, c3 }
 }
 
 macro_rules! def_alias(
@@ -523,32 +523,32 @@ macro_rules! def_alias(
 
 def_alias! {
     { Mat2,   Matrix2,   f32 },
-    { Mat2x3, Matrix2x3, f32 },
-    { Mat2x4, Matrix2x4, f32 },
-
     { Mat3x2, Matrix3x2, f32 },
-    { Mat3,   Matrix3,   f32 },
-    { Mat3x4, Matrix3x4, f32 },
-
     { Mat4x2, Matrix4x2, f32 },
+
+    { Mat2x3, Matrix2x3, f32 },
+    { Mat3,   Matrix3,   f32 },
     { Mat4x3, Matrix4x3, f32 },
+
+    { Mat2x4, Matrix2x4, f32 },
+    { Mat3x4, Matrix3x4, f32 },
     { Mat4,   Matrix4,   f32 },
 
     { DMat2,   Matrix2,   f64 },
-    { DMat2x3, Matrix2x3, f64 },
-    { DMat2x4, Matrix2x4, f64 },
-
     { DMat3x2, Matrix3x2, f64 },
-    { DMat3,   Matrix3,   f64 },
-    { DMat3x4, Matrix3x4, f64 },
-
     { DMat4x2, Matrix4x2, f64 },
+
+    { DMat2x3, Matrix2x3, f64 },
+    { DMat3,   Matrix3,   f64 },
     { DMat4x3, Matrix4x3, f64 },
+
+    { DMat2x4, Matrix2x4, f64 },
+    { DMat3x4, Matrix3x4, f64 },
     { DMat4,   Matrix4,   f64 }
 }
 
 impl<T: BaseFloat> Matrix2<T> {
-    /// Extends _self_ to a `Matrix2x3` by appending the column vector `z`.
+    /// Extends _self_ to a `Matrix3x2` by appending the column vector `z`.
     ///
     /// # Example
     ///
@@ -556,20 +556,20 @@ impl<T: BaseFloat> Matrix2<T> {
     /// use glm::*;
     ///
     /// let m2 = mat2(1., 2., 3., 4.);
-    /// let m2x3 = mat2x3(1., 2., 3., 4., 0., 0.);
-    /// assert_eq!(m2.extend(vec2(0., 0.)), m2x3);
+    /// let m3x2 = mat3x2(1., 2., 3., 4., 0., 0.);
+    /// assert_eq!(m2.extend(vec2(0., 0.)), m3x2);
     /// ```
     #[inline]
-    pub fn extend(&self, z: Vector2<T>) -> Matrix2x3<T> {
-        Matrix2x3::new(self[0], self[1], z)
+    pub fn extend(&self, z: Vector2<T>) -> Matrix3x2<T> {
+        Matrix3x2::new(self[0], self[1], z)
     }
 }
 
 impl<T: BaseFloat> Matrix3<T> {
-    /// Extends _self_ to a `Matrix3x4` by appending the column vector `w`.
+    /// Extends _self_ to a `Matrix4x3` by appending the column vector `w`.
     #[inline]
-    pub fn extend(&self, w: Vector3<T>) -> Matrix3x4<T> {
-        Matrix3x4::new(self[0], self[1], self[2], w)
+    pub fn extend(&self, w: Vector3<T>) -> Matrix4x3<T> {
+        Matrix4x3::new(self[0], self[1], self[2], w)
     }
 }
 
@@ -581,7 +581,7 @@ mod test {
 
     #[test]
     fn test_index() {
-        let m = mat3x4(1., 2., 3., 2., 4., 6., 3., 6., 9., 4., 8., 12.);
+        let m = mat4x3(1., 2., 3., 2., 4., 6., 3., 6., 9., 4., 8., 12.);
         assert_eq!(m[3], vec3(4., 8., 12.));
         assert_eq!(m[1], m.c1);
         assert_eq!(m[2][0], 3.);
@@ -597,7 +597,7 @@ mod test {
 
     #[test]
     fn test_mul_v() {
-        let m = mat2x3(1., 2., 3., 4., 5., 6.);
+        let m = mat3x2(1., 2., 3., 4., 5., 6.);
         let v = vec3(-2., 0., 2.);
         let p = vec2(8., 8.);
         assert_eq!(m * v, p);

--- a/src/mat/traits.rs
+++ b/src/mat/traits.rs
@@ -48,7 +48,7 @@ C: GenFloatVec<T>
     type R: GenFloatVec<T>;
 
     /// Type of transpose matrix.
-    type Transpose: GenMat<T, Self::R, R = C>;
+    type Transpose: GenMat<T, Self::R, R = C, Transpose = Self>;
 
     /// Returns the transpose matrix.
     ///
@@ -57,8 +57,8 @@ C: GenFloatVec<T>
     /// ```
     /// use glm::GenMat;    // bing the method into scope.
     ///
-    /// let m = glm::mat2x3(1., 2., 3., 4., 5., 6.);
-    /// let tm = glm::mat3x2(1., 3., 5., 2., 4., 6.);
+    /// let m = glm::mat3x2(1., 2., 3., 4., 5., 6.);
+    /// let tm = glm::mat2x3(1., 3., 5., 2., 4., 6.);
     /// assert_eq!(tm, m.transpose());
     /// ```
     fn transpose(&self) -> Self::Transpose;


### PR DESCRIPTION
- Fixes E2077 warning and closes #12.
- Fixes a silly bug, caused by `dche` only use square matrices.
- Bump version to 0.2.0.