### PR TITLE
Fix breakage with Order.min and Order.max on nightly

### DIFF
--- a/src/basenum.rs
+++ b/src/basenum.rs
@@ -53,7 +53,7 @@ pub trait BaseNum
     ///
     /// ```
     /// use glm::BaseNum;
-    /// assert_eq!(1i32.min(2i32), 1i32);
+    /// assert_eq!(BaseNum::min(1i32, 2i32), 1i32);
     /// ```
     fn min(self, other: Self) -> Self;
 
@@ -63,7 +63,7 @@ pub trait BaseNum
     ///
     /// ```
     /// use glm::BaseNum;
-    /// assert_eq!(1i32.max(2i32), 2i32);
+    /// assert_eq!(BaseNum::max(1i32, 2i32), 2i32);
     /// ```
     fn max(self, other: Self) -> Self;
 }


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/42496, `min` and `max` methods have been added to the `Ord` trait, which causes an issue using `glm`'s `BaseNum::min/max` functions for a type that implements `Ord`. This was reported [here](https://github.com/rust-lang/rust/issues/43667)

This PR currently just clarifies which `min`/`max` function to use in the docs to fix tests. It's probably not what you want long-term. If you require `BaseNum` to be compared, then you could add an `Ord` bound and remove the `min` and `max` methods.