### PR TITLE
Don't use types as traits in macros

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -129,7 +129,7 @@ pub trait GenType: GenFloat<f32> {}
 pub trait GenDType: GenFloat<f64> {}
 
 macro_rules! impl_GenFloat_for_scalar(
-    ($t: ty, $gt: ty) => {
+    ($t: ty, $gt: path) => {
         impl_GenNum_for_scalar! { $t }
         impl GenFloat<$t> for $t {
             fn fma(&self, b: &$t, c: &$t) -> $t {


### PR DESCRIPTION
Hello.

We've found that this crate is affected by an upcoming bugfix in `rustc` - https://github.com/rust-lang/rust/pull/48502 (`ty` fragments are no longer accepted as traits in trait impls).
This PR fixes the deprecated use of `ty`.