### PR TITLE
Fix a little bit of "Por Grammer"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! *glm-rs* is yet another Rust math library for graphics applications.
 //! Inspired by the great [GLM](glm.g-truc.net) library for C++, the goal is to
-//! provide familiar math API to porgrammers who knows GLSL as well.
+//! provide a familiar math API to programmers who know GLSL as well.
 //!
 //! ## Differences to GLSL specification
 //!


### PR DESCRIPTION
Typo fix to lib.rs documentation (This showed up on the first page of the documentation.)