### PR TITLE
Mark packDouble2x32 function as unsafe

### DIFF
--- a/src/builtin/pack.rs
+++ b/src/builtin/pack.rs
@@ -256,8 +256,8 @@ pub fn unpackSnorm4x8(p: u32) -> Vec4 {
 /// ```
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn packDouble2x32(v: UVec2) -> f64 {
-    let f: &f64 = unsafe { mem::transmute(&v) };
+pub unsafe fn packDouble2x32(v: UVec2) -> f64 {
+    let f: &f64 = mem::transmute(&v);
     *f
 }
 


### PR DESCRIPTION
https://github.com/dche/glm-rs/blob/df5a98940ad617a22aa65f7b19f0f39988373f13/src/builtin/pack.rs#L259-L262
Hello, the unsafe function called needs to ensure that the parameter must be:[https://doc.rust-lang.org/std/mem/fn.transmute.html](url)

It uses the mem::transmute function, which can lead to undefined behavior if used incorrectly. The mem::transmute function is used to reinterpret the memory of one type as another type, which can be dangerous if the types have different sizes or alignment requirements. Therefore, any function that uses mem::transmute must be marked as unsafe to indicate that the caller must take care to ensure that it is used correctly. The developer who calls the uninit_vector function may not notice this safety requirement.

Marking them unsafe also means that callers must make sure they know what they're doing.
