### PR TITLE
added assign operators for vec types 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ num-traits = { version = "0.2" }
 
 [dev-dependencies]
 quickcheck = "^1.0.3"
+
+[features]
+default = []
+wrapping_ops = []


### PR DESCRIPTION
### Description
Added assign operators (`+=`, `-=`, `*=`, `/=`) for `vec` types.

### Features
- Implemented assign operators for all `vec` types.  
- Added optional `wrapping_ops` feature:
  - Enables `wrapping_add`, `wrapping_sub`, and `wrapping_mul` for arithmetic operations.
